### PR TITLE
v0.4.3. Add check for all outdated installed dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.3
+
+* Add check to update all outdated installed dependencies.
+* Retry if `mix deps.get` times out (can happen if ElixirLS kicks it off before Ironman does)
+
 ## 0.4.2
 
 * Enabled credo config check

--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ Contributions welcome. Specifically looking to:
 * [X] Self check/upgrade version
 * [X] Check for mix.exs file before running
 * [X] Check/warn for uncommitted files before running
-* [ ] Check all dependencies for updates
+* [X] Check all dependencies for updates
 * [X] Ask what additional dependencies to add
 * [ ] Add test to ensure README.md referenced version is up to date with project version

--- a/lib/ironman/checks/update_all_deps.ex
+++ b/lib/ironman/checks/update_all_deps.ex
@@ -1,0 +1,24 @@
+defmodule Ironman.Checks.UpdateAllDeps do
+  @moduledoc false
+  alias Ironman.Config
+  alias Ironman.Utils.Deps
+
+  @spec run(Config.t()) :: {:error, any()} | {:no | :yes | :up_to_date | :skip, Config.t()}
+  def run(%Config{skipped_upgrades: skipped_upgrades} = config) do
+    config
+    |> Deps.get_installed_deps()
+    |> Enum.map(&String.to_atom/1)
+    |> Enum.reject(&Enum.member?(skipped_upgrades, &1))
+    |> Enum.reduce({:skip, config}, fn dep, {ret, config} ->
+      case Deps.check_dep_version(config, dep) do
+        {:yes, config} -> {maximum(ret, :yes), config}
+        {:no, config} -> {maximum(ret, :no), config}
+        {:up_to_date, config} -> {maximum(ret, :up_to_date), config}
+      end
+    end)
+  end
+
+  defp maximum(x, y) when x == :yes or y == :yes, do: :yes
+  defp maximum(x, y) when x == :no or y == :no, do: :no
+  defp maximum(x, y) when x == :up_to_date or y == :up_to_date, do: :up_to_date
+end

--- a/lib/ironman/config.ex
+++ b/lib/ironman/config.ex
@@ -30,7 +30,8 @@ defmodule Ironman.Config do
           starting_project_config: keyword(),
           credo_exs: String.t() | nil,
           coveralls_json: String.t() | nil,
-          changed: MapSet.t(atom())
+          changed: MapSet.t(atom()),
+          skipped_upgrades: MapSet.t(atom())
         }
   defstruct mix_exs: nil,
             gitignore: nil,
@@ -42,7 +43,8 @@ defmodule Ironman.Config do
             starting_project_config: nil,
             credo_exs: nil,
             coveralls_json: nil,
-            changed: MapSet.new()
+            changed: MapSet.new(),
+            skipped_upgrades: MapSet.new()
 
   def new!() do
     %__MODULE__{

--- a/lib/ironman/runner.ex
+++ b/lib/ironman/runner.ex
@@ -1,6 +1,6 @@
 defmodule Ironman.Runner do
   @moduledoc false
-  alias Ironman.Checks.{AddDeps, CoverallsConfig, CredoConfig, DialyzerConfig, GitHooksConfig, SimpleDep}
+  alias Ironman.Checks.{AddDeps, CoverallsConfig, CredoConfig, DialyzerConfig, GitHooksConfig, SimpleDep, UpdateAllDeps}
   alias Ironman.{Config, Utils}
 
   @checks [
@@ -15,6 +15,7 @@ defmodule Ironman.Runner do
     :git_hooks_config,
     :coveralls_config,
     :credo_exs,
+    :update_all_deps,
     :add_deps
   ]
 
@@ -71,6 +72,9 @@ defmodule Ironman.Runner do
 
   def run_check(%Config{} = config, :credo_exs),
     do: config |> CredoConfig.run() |> unwrap(:credo_exs)
+
+  def run_check(%Config{} = config, :update_all_deps),
+    do: config |> UpdateAllDeps.run() |> unwrap(:update_all_deps)
 
   def run_check(%Config{} = config, :add_deps),
     do: config |> AddDeps.run() |> unwrap(:add_deps)

--- a/lib/ironman/utils/cmd.ex
+++ b/lib/ironman/utils/cmd.ex
@@ -2,7 +2,7 @@ defmodule Ironman.Utils.Cmd do
   @moduledoc false
   @behaviour Ironman.Utils.Cmd.Impl
 
-  @spec run([String.t()]) :: {:ok, String.t()} | {:error, non_neg_integer()}
+  @spec run([String.t()]) :: {:ok, String.t()} | {:error, {non_neg_integer(), String.t()}}
   def run(args) do
     impl().run(args)
   end

--- a/lib/ironman/utils/cmd/default_impl.ex
+++ b/lib/ironman/utils/cmd/default_impl.ex
@@ -2,11 +2,11 @@ defmodule Ironman.Utils.Cmd.DefaultImpl do
   @moduledoc false
   @behaviour Ironman.Utils.Cmd.Impl
 
-  @spec run([String.t()]) :: {:ok, String.t()} | {:error, non_neg_integer()}
+  @spec run([String.t()]) :: {:ok, String.t()} | {:error, {non_neg_integer(), String.t()}}
   def run([h | t]) do
     case System.cmd(h, t, stderr_to_stdout: true) do
       {output, 0} -> {:ok, output}
-      {_output, return_code} -> {:error, return_code}
+      {output, return_code} -> {:error, {return_code, output}}
     end
   end
 end

--- a/lib/ironman/utils/cmd/impl.ex
+++ b/lib/ironman/utils/cmd/impl.ex
@@ -1,4 +1,4 @@
 defmodule Ironman.Utils.Cmd.Impl do
   @moduledoc false
-  @callback run(args :: [String.t()]) :: {:ok, String.t()} | {:error, non_neg_integer()}
+  @callback run(args :: [String.t()]) :: {:ok, String.t()} | {:error, {non_neg_integer(), String.t()}}
 end

--- a/lib/ironman/utils/deps.ex
+++ b/lib/ironman/utils/deps.ex
@@ -138,8 +138,21 @@ defmodule Ironman.Utils.Deps do
   end
 
   @spec skip_upgrade(Config.t(), any()) :: {:no, Config.t()}
-  def skip_upgrade(%Config{} = config, dep) do
-    Utils.puts("\nSkipping upgrade of #{dep}")
-    {:no, config}
+  def skip_upgrade(%Config{skipped_upgrades: skipped_upgrades} = config, dep) do
+    Utils.puts("\nDeclined upgrade of #{dep}")
+    {:no, %{config | skipped_upgrades: MapSet.put(skipped_upgrades, dep)}}
+  end
+
+  def get_installed_deps(%Config{} = config) do
+    deps_str =
+      "defp deps do\\s*?\\[\\s*?({.*?})\\s*?]\\s*?end"
+      |> Regex.compile!("s")
+      |> Regex.run(Config.get(config, :mix_exs))
+      |> Enum.at(1)
+
+    "{:([a-z_]*)"
+    |> Regex.compile!()
+    |> Regex.scan(deps_str)
+    |> Enum.map(&Enum.at(&1, 1))
   end
 end

--- a/lib/mix/tasks/suit_up.ex
+++ b/lib/mix/tasks/suit_up.ex
@@ -2,6 +2,8 @@ defmodule Mix.Tasks.SuitUp do
   @moduledoc false
   use Mix.Task
 
+  @shortdoc "Runs Ironman to suit up your mix project"
+  @spec run(any()) :: nil | :ok | {:ok, binary()}
   def run(_) do
     Ironman.run()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ironman.MixProject do
   def project do
     [
       app: :ironman,
-      version: "0.4.2",
+      version: "0.4.3",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/ironman/checks/add_deps_test.exs
+++ b/test/ironman/checks/add_deps_test.exs
@@ -47,7 +47,7 @@ defmodule Ironman.Checks.AddDepsTest do
       MoxHelpers.expect_dep_http(:foo_bar, "1.2.4")
       MoxHelpers.expect_io("\nUpgrade foo_bar from ~> 1.2.3 to 1.2.4? [Yn] ", "n")
       MoxHelpers.expect_io("\nInstall any other dependencies? [Yn] ", "n")
-
+      config = %{config | skipped_upgrades: MapSet.new([:foo_bar])}
       assert {:no, ^config} = AddDeps.run(config)
     end
 


### PR DESCRIPTION
Checks all installed deps and prompts to update any that are out of date. Also added code to recover from `mix deps.get` collision/timeout which happens often with ElixirLS.