### PR TITLE
Remove outdated halt-exit-status for dialyxir 1.0.0

### DIFF
--- a/lib/ironman/checks/git_hooks_config.ex
+++ b/lib/ironman/checks/git_hooks_config.ex
@@ -102,7 +102,7 @@ defmodule Ironman.Checks.GitHooksConfig do
 
     tasks =
       if Deps.get_configured_version(config, :dialyxir) do
-        tasks <> "\n            \"mix dialyzer --halt-exit-status\","
+        tasks <> "\n            \"mix dialyzer\","
       else
         tasks
       end

--- a/test/ironman/checks/git_hooks_config_test.exs
+++ b/test/ironman/checks/git_hooks_config_test.exs
@@ -62,7 +62,7 @@ defmodule Ironman.Checks.GitHooksConfigTest do
       assert "use Mix.Config\n\n" = Config.get(config2, :config_exs)
       assert String.starts_with?(Config.get(config2, :config_dev_exs), "use Mix.Config\n\n\n\nconfig :git_hooks,")
       refute String.contains?(Config.get(config2, :config_dev_exs), "credo --strict")
-      refute String.contains?(Config.get(config2, :config_dev_exs), "dialyzer --halt-exit-status")
+      refute String.contains?(Config.get(config2, :config_dev_exs), "dialyzer")
       assert "use Mix.Config\n\n" = Config.get(config2, :config_test_exs)
       assert "use Mix.Config\n\n" = Config.get(config2, :config_prod_exs)
     end
@@ -78,7 +78,7 @@ defmodule Ironman.Checks.GitHooksConfigTest do
     assert "use Mix.Config\n\n" = Config.get(config2, :config_exs)
     assert String.starts_with?(Config.get(config2, :config_dev_exs), "use Mix.Config\n\nconfig :git_hooks,")
     assert String.contains?(Config.get(config2, :config_dev_exs), "credo --strict")
-    refute String.contains?(Config.get(config2, :config_dev_exs), "dialyzer --halt-exit-status")
+    refute String.contains?(Config.get(config2, :config_dev_exs), "dialyzer")
     assert "use Mix.Config\n\n" = Config.get(config2, :config_test_exs)
     assert "use Mix.Config\n\n" = Config.get(config2, :config_prod_exs)
   end
@@ -93,7 +93,7 @@ defmodule Ironman.Checks.GitHooksConfigTest do
     assert "use Mix.Config\n\n" = Config.get(config2, :config_exs)
     assert String.starts_with?(Config.get(config2, :config_dev_exs), "use Mix.Config\n\nconfig :git_hooks,")
     refute String.contains?(Config.get(config2, :config_dev_exs), "credo --strict")
-    assert String.contains?(Config.get(config2, :config_dev_exs), "dialyzer --halt-exit-status")
+    assert String.contains?(Config.get(config2, :config_dev_exs), "dialyzer")
     assert "use Mix.Config\n\n" = Config.get(config2, :config_test_exs)
     assert "use Mix.Config\n\n" = Config.get(config2, :config_prod_exs)
   end


### PR DESCRIPTION
- Running "mix dialyzer --halt-exit-status" with dialyxir 1.0.0 outputs
the following in CLI:

`halt_exit_status is no longer a valid CLI argument.`