### PR TITLE
add a check for the existence of the config/config.exs file fixes #23

### DIFF
--- a/lib/ironman/utils/file.ex
+++ b/lib/ironman/utils/file.ex
@@ -5,6 +5,8 @@ defmodule Ironman.Utils.File do
   def exists?(path), do: impl().exists?(path)
   def read!(path), do: impl().read!(path)
   def write!(path, contents), do: impl().write!(path, contents)
+  def mkdir!(path), do: impl().mkdir!(path)
+  def touch!(filename), do: impl().touch!(filename)
 
   defp impl, do: Application.get_env(:ironman, :file, Ironman.Utils.File.DefaultImpl)
 end

--- a/lib/ironman/utils/file/default_impl.ex
+++ b/lib/ironman/utils/file/default_impl.ex
@@ -5,4 +5,6 @@ defmodule Ironman.Utils.File.DefaultImpl do
   def exists?(path), do: File.exists?(path)
   def read!(path), do: File.read!(path)
   def write!(path, contents), do: File.write!(path, contents)
+  def mkdir!(path), do: File.mkdir!(path)
+  def touch!(filename), do: File.touch!(filename)
 end

--- a/lib/ironman/utils/file/impl.ex
+++ b/lib/ironman/utils/file/impl.ex
@@ -4,4 +4,6 @@ defmodule Ironman.Utils.File.Impl do
   @callback exists?(path :: String.t()) :: boolean()
   @callback read!(path :: String.t()) :: String.t()
   @callback write!(path :: String.t(), contents :: String.t()) :: :ok
+  @callback mkdir!(path :: String.t()) :: :ok
+  @callback touch!(filename :: String.t()) :: :ok
 end

--- a/test/support/mox_helpers.ex
+++ b/test/support/mox_helpers.ex
@@ -44,4 +44,14 @@ defmodule Ironman.Test.Helpers.MoxHelpers do
     Ironman.MockFile
     |> expect(:write!, fn ^file, ^contents -> :ok end)
   end
+
+  def expect_directory_create(path) do
+    Ironman.MockFile
+    |> expect(:mkdir!, fn ^path -> :ok end)
+  end
+
+  def expect_file_touch!(filename) do
+    Ironman.MockFile
+    |> expect(:touch!, fn ^filename -> :ok end)
+  end
 end


### PR DESCRIPTION
Fixes issue #23 by creating the config/config.exs file if it doesn't exist. 