### PR TITLE
Handle missing /config or /config/config.exs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+* Handle missing /config or /config/config.exs
+
 ## 0.4.5
 
 * Update git hooks config to new syntax

--- a/lib/ironman/checks/git_hooks_config.ex
+++ b/lib/ironman/checks/git_hooks_config.ex
@@ -43,11 +43,17 @@ defmodule Ironman.Checks.GitHooksConfig do
     config_exs = Config.get(config, :config_exs)
 
     config_exs =
-      if Regex.match?(~r/#\s+import_config "\#{Mix.env\(\)}.exs"/, config_exs) do
-        Utils.puts("Uncommenting import_config in config.exs")
-        Regex.replace(~r/#\s+import_config "\#{Mix.env\(\)}.exs"/, config_exs, "import_config \"\#{Mix.env()}.exs\"")
-      else
-        config_exs
+      cond do
+        config_exs == nil ->
+          Utils.puts("Adding config/config.exs")
+          "import Config\n\nimport_config \"\#{Mix.env()}.exs\""
+
+        Regex.match?(~r/#\s+import_config "\#{Mix.env\(\)}.exs"/, config_exs) ->
+          Utils.puts("Uncommenting import_config in config.exs")
+          Regex.replace(~r/#\s+import_config "\#{Mix.env\(\)}.exs"/, config_exs, "import_config \"\#{Mix.env()}.exs\"")
+
+        true ->
+          config_exs
       end
 
     Config.set(config, :config_exs, config_exs)

--- a/lib/ironman/utils.ex
+++ b/lib/ironman/utils.ex
@@ -143,6 +143,8 @@ defmodule Ironman.Utils do
     write_if_changed(config, :config_prod_exs)
     write_if_changed(config, :coveralls_json)
     write_if_changed(config, :credo_exs)
+
+    :ok
   end
 
   @spec write_if_changed(Config.t(), atom()) :: :ok
@@ -150,6 +152,7 @@ defmodule Ironman.Utils do
     if Config.changed?(config, key) do
       file = path_of(key)
       puts("Writing new #{file}...")
+      IFile.mkdir_p!(Path.dirname(file))
       IFile.write!(file, Config.get(config, key))
     end
   end

--- a/lib/ironman/utils/file.ex
+++ b/lib/ironman/utils/file.ex
@@ -5,6 +5,7 @@ defmodule Ironman.Utils.File do
   def exists?(path), do: impl().exists?(path)
   def read!(path), do: impl().read!(path)
   def write!(path, contents), do: impl().write!(path, contents)
+  def mkdir_p!(path), do: impl().mkdir_p!(path)
 
   defp impl, do: Application.get_env(:ironman, :file, Ironman.Utils.File.DefaultImpl)
 end

--- a/lib/ironman/utils/file/default_impl.ex
+++ b/lib/ironman/utils/file/default_impl.ex
@@ -5,4 +5,5 @@ defmodule Ironman.Utils.File.DefaultImpl do
   def exists?(path), do: File.exists?(path)
   def read!(path), do: File.read!(path)
   def write!(path, contents), do: File.write!(path, contents)
+  def mkdir_p!(path), do: File.mkdir_p!(path)
 end

--- a/lib/ironman/utils/file/impl.ex
+++ b/lib/ironman/utils/file/impl.ex
@@ -4,4 +4,5 @@ defmodule Ironman.Utils.File.Impl do
   @callback exists?(path :: String.t()) :: boolean()
   @callback read!(path :: String.t()) :: String.t()
   @callback write!(path :: String.t(), contents :: String.t()) :: :ok
+  @callback mkdir_p!(path :: String.t()) :: :ok
 end

--- a/test/support/mox_helpers.ex
+++ b/test/support/mox_helpers.ex
@@ -44,4 +44,14 @@ defmodule Ironman.Test.Helpers.MoxHelpers do
     Ironman.MockFile
     |> expect(:write!, fn ^file, ^contents -> :ok end)
   end
+
+  def expect_file_write!(file) do
+    Ironman.MockFile
+    |> expect(:write!, fn ^file, _contents -> :ok end)
+  end
+
+  def expect_mkdir_p!(path) do
+    Ironman.MockFile
+    |> expect(:mkdir_p!, fn ^path -> :ok end)
+  end
 end


### PR DESCRIPTION
Handle a missing config.exs and also `mkdir_p!` to ensure `/config` exists. Fixes #23.